### PR TITLE
fix(docker): remove unnecessary image tag from compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ should return the number of users that visited a page at least twice during the 
 You need to build the containers by executing the following commands from the root of the project:
 
 ```bash
-docker-compose build
 docker-compose up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   backend:
-    image: python:3.12
     container_name: backend
     build:
       context: .
@@ -15,7 +14,6 @@ services:
       - database
 
   database:
-    image: mongo:8.0.0
     container_name: mongo
     build:
       context: .


### PR DESCRIPTION
This PR removes the unnecessary  image tag from the docker-compose file. The images are already specified in each custom image Dockerfile. Specifying them in the compose file incorrectly allow you to start the containers without building the custom images first.

Now if you do `docker compose up`, the custom images are automatically built before starting the containers.