### PR TITLE
misc: use Python slim image for Docker container

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Python image as the base image
-FROM python:3.12
+FROM python:3.12-slim
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
Sometime candidates have connections that are a bit slow. Using a slim image for Python reduce the final size to ~340MB instead of 1.2GB, so it's faster to download during the interview.